### PR TITLE
Add tunable Breath grant physics to world tick

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "cycleLengthHours": 1,
+  "globalDecayRate": 0,
+  "promptCost": 1,
+  "baseBreathIntervalCycles": 24,
+  "baseBreathGrantAmount": 1
+}

--- a/scripts/world-tick.mjs
+++ b/scripts/world-tick.mjs
@@ -1,0 +1,78 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.join(__dirname, "..");
+
+const CONFIG_PATH = path.join(ROOT, "config.json");
+const WORLDS_PATH = path.join(ROOT, "public", "worlds");
+
+function readJson(filePath, fallback = {}) {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    console.warn(`[world-tick] Failed to read ${filePath}: ${error.message}`);
+    return fallback;
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+const config = readJson(CONFIG_PATH, {
+  cycleLengthHours: 1,
+  globalDecayRate: 0,
+  promptCost: 1,
+  baseBreathIntervalCycles: 24,
+  baseBreathGrantAmount: 1
+});
+
+if (!fs.existsSync(WORLDS_PATH)) {
+  console.log(`[world-tick] No worlds directory found at ${WORLDS_PATH}; nothing to tick.`);
+  process.exit(0);
+}
+
+const worldDirs = fs
+  .readdirSync(WORLDS_PATH, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const tickAtIso = new Date().toISOString();
+
+for (const world of worldDirs) {
+  const statePath = path.join(WORLDS_PATH, world, "state.json");
+  const electrumPath = path.join(WORLDS_PATH, world, "electrum.json");
+
+  if (!fs.existsSync(statePath) || !fs.existsSync(electrumPath)) {
+    continue;
+  }
+
+  const state = readJson(statePath, {});
+
+  state.breathsAvailable = typeof state.breathsAvailable === "number" ? state.breathsAvailable : 0;
+  state.breathCounterCycles = typeof state.breathCounterCycles === "number" ? state.breathCounterCycles : 0;
+  state.cycle = typeof state.cycle === "number" ? state.cycle : 0;
+  state.lastTickAt = Object.prototype.hasOwnProperty.call(state, "lastTickAt") ? state.lastTickAt : null;
+
+  state.cycle += 1;
+  state.breathCounterCycles += 1;
+
+  let breathGranted = false;
+  if (state.breathCounterCycles >= config.baseBreathIntervalCycles) {
+    state.breathsAvailable += config.baseBreathGrantAmount;
+    state.breathCounterCycles = 0;
+    breathGranted = true;
+  }
+
+  state.lastTickAt = tickAtIso;
+
+  writeJson(statePath, state);
+
+  console.log(
+    `[world-tick] world=${world} cycle=${state.cycle} breathCounterCycles=${state.breathCounterCycles} breathsAvailable=${state.breathsAvailable} breathGranted=${breathGranted}`
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce a tunable, physics-only Breath grant mechanism so worlds can receive configurable Breath units on a schedule rather than having the behavior hardwired. 
- Provide simple knobs in a top-level config for operators to tune interval and grant size while keeping existing tick/decay behavior unchanged. 

### Description
- Add `config.json` with existing tick knobs and a new `baseBreathGrantAmount` key, preserving `cycleLengthHours`, `globalDecayRate`, `promptCost`, and `baseBreathIntervalCycles`, and default values. 
- Add `scripts/world-tick.mjs` that loads `config.json`, iterates `public/worlds/<world>/`, and for each world that has `state.json` and `electrum.json` ensures default fields: `breathsAvailable` (default `0`), `breathCounterCycles` (default `0`), `cycle` (default `0`), and `lastTickAt` (default `null`). 
- Implement tick physics: increment `state.cycle` and `state.breathCounterCycles` each tick, and if `state.breathCounterCycles >= config.baseBreathIntervalCycles` then add `config.baseBreathGrantAmount` to `state.breathsAvailable` and reset the counter. `state.lastTickAt` is updated to the tick time each run. 
- Logging updated to include `breathsAvailable` and `breathGranted` (boolean) per world tick, and no AI API calls, decay logic, or dependencies were changed. 

### Testing
- Ran `node scripts/world-tick.mjs` which executed cleanly and exited with a no-worlds message when `public/worlds` is absent; the command used was `node scripts/world-tick.mjs`. 
- Because this repository snapshot has no `public/worlds` directory, no existing `state.json` files were modified in this run, but the script enforces defaults for `breathsAvailable` etc. when such files are present. 
- The script writes updated `state.json` files with new fields when worlds exist and logs per-world tick output including `breathsAvailable` and `breathGranted`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cf483ed0832ebd54c863ce8eb657)